### PR TITLE
fix a bug of -- full-line comments

### DIFF
--- a/startup.mu4
+++ b/startup.mu4
@@ -152,7 +152,8 @@ compiler
 forth
 
 ( A nice way to do full-line comments with no trailing delimiter.)
-: --  ctrl J parse  2drop ;  ( throw away until a newline)
+: --  parsed drop 2 + c@  ctrl J negate  + 0=  first +!
+      ctrl J parse  2drop ;  ( throw away until a newline)
 compiler
 : --  \f -- ;
 forth


### PR DESCRIPTION
As `mu_scan` will consume newline char if it follows a word, `--` will comment out next line if there is nothing in its own line. For example, following code will show nothing.

```
--
." foo"
```

The fix in pull request is a little weird, as there is no `if` and `=` at the time of its definition. A much clear version would be:

```
: --  parsed drop 2 + c@ bl = if
      ctrl J parse  2drop then ;
```
