### PR TITLE
Make GitHub detect *.{mu4,d4,scr} as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.mu4 linguist-language=Forth
+*.d4 linguist-language=Forth
+*.scr linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.mu4`, `.d4`, and `.scr` files as Forth.  This would make your repository show up in Forth search results etc.

Thanks!