### PR TITLE
Add 'ld target/common/serial.mu4' to target/common/serial-terminal.mu4

### DIFF
--- a/mu/target/common/serial-terminal.mu4
+++ b/mu/target/common/serial-terminal.mu4
@@ -4,6 +4,12 @@
 
 ( Simple terminal that talks to serial port.)
 
+( @muforth: serial-terminal.mu4 depends on tty-target which is defined in
+  serial.mu4.  Let's just load it here rather than loading separately.
+  --@0x0dada )
+
+ld target/common/serial.mu4
+
 ( Keymaps)
 -: ( self)  emit  0 ;  256 defarray+ term-keys
    ( nop)       ' 0    256 defarray+ term-esc-keys


### PR DESCRIPTION
...since the latter depends on tty-target which is defined in the former.